### PR TITLE
VkMemoryRequirements2 sType must be STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2

### DIFF
--- a/src/rtxApp.cpp
+++ b/src/rtxApp.cpp
@@ -220,7 +220,8 @@ bool RtxApp::CreateAS(const VkAccelerationStructureTypeNV type,
     memoryRequirementsInfo.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV;
     memoryRequirementsInfo.accelerationStructure = _as.accelerationStructure;
 
-    VkMemoryRequirements2 memoryRequirements;
+    VkMemoryRequirements2 memoryRequirements = {};
+    memoryRequirements.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     vkGetAccelerationStructureMemoryRequirementsNV(mDevice, &memoryRequirementsInfo, &memoryRequirements);
 
     VkMemoryAllocateInfo memoryAllocateInfo;
@@ -484,13 +485,15 @@ void RtxApp::CreateScene() {
         memoryRequirementsInfo.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
         memoryRequirementsInfo.accelerationStructure = mesh.blas.accelerationStructure;
 
-        VkMemoryRequirements2 memReqBLAS;
+        VkMemoryRequirements2 memReqBLAS = {};
+        memReqBLAS.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
         vkGetAccelerationStructureMemoryRequirementsNV(mDevice, &memoryRequirementsInfo, &memReqBLAS);
 
         maximumBlasSize = Max(maximumBlasSize, memReqBLAS.memoryRequirements.size);
     }
 
-    VkMemoryRequirements2 memReqTLAS;
+    VkMemoryRequirements2 memReqTLAS = {};
+    memReqTLAS.sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2;
     memoryRequirementsInfo.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
     memoryRequirementsInfo.accelerationStructure = mScene.topLevelAS.accelerationStructure;
     vkGetAccelerationStructureMemoryRequirementsNV(mDevice, &memoryRequirementsInfo, &memReqTLAS);


### PR DESCRIPTION
VkMemoryRequirements2 structures don't currently set sType to VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2 as is required by the spec.
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkMemoryRequirements2-sType-sType

VkMemoryRequirements2 structures also do not currently set pNext to NULL or to a valid instance of VkMemoryDedicatedRequirements.
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkMemoryRequirements2-pNext-pNext