### PR TITLE
chore(cmake): copy _data asset folder next to the runtime binary afte…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,13 @@ include_directories(
 
 add_executable(${PROJECT_NAME} ${HEADERS} ${SOURCES})
 
+add_custom_command(
+        TARGET rtxON POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/_data
+        $<TARGET_FILE_DIR:rtxON>/_data
+)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 
 target_link_libraries(${PROJECT_NAME} glfw)


### PR DESCRIPTION
…r every build

Adds a POST_BUILD `copy_directory` step to CMake that places the entire
`_data` tree (models, shaders, HDRIs, etc.) beside the compiled executable.
This lets the engine load assets with the existing relative paths
(`_data/scenes/…`, `_data/shaders/…`) no matter which generator is used
(CLion/ninja, Visual Studio, plain make) and eliminates the zero-byte Vulkan
buffer crash when the OBJ file can’t be found.